### PR TITLE
Add CBA-style component headers

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,4 @@
+* text=auto
+*.png binary
+*.jpg binary
+*.paa binary

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,27 @@
+# Windows thumbnail cache files
+Thumbs.db
+ehthumbs.db
+ehthumbs_vista.db
+
+# Folder config file
+Desktop.ini
+
+# Recycle Bin used on file shares
+$RECYCLE.BIN/
+
+# Windows Installer files
+*.cab
+*.msi
+*.msm
+*.msp
+
+# Windows shortcuts
+*.lnk
+
+# ARMA Tools
+*.cache
+*.pbo
+*.swp
+*.swo
+*.biprivatekey
+*.log

--- a/addons/overthrow_main/CfgSettings.hpp
+++ b/addons/overthrow_main/CfgSettings.hpp
@@ -1,0 +1,17 @@
+class CfgSettings {
+    class CBA {
+        class Caching {
+            // did not turn on--not sure if using CBA caching
+            functions = 0;
+        };
+        // @see https://github.com/CBATeam/CBA_A3/wiki/Versioning-System
+        class Versioning {
+            class PREFIX {
+                class dependencies {
+                    CBA_A3[] = {"cba_main", REQUIRED_CBA_VERSION, "(true)"};
+                    ACE3[] = {"ace_main", REQUIRED_ACE_VERSION, "(true)"};
+                };
+            };
+        };
+    };
+};

--- a/addons/overthrow_main/config.cpp
+++ b/addons/overthrow_main/config.cpp
@@ -1,3 +1,5 @@
+#include "script_component.hpp"
+
 #include "ui\dialogs\defines.hpp"
 #include "ui\dialogs\stats.hpp"
 #include "ui\dialogs\shop.hpp"
@@ -13,7 +15,7 @@ class CfgPatches
 	class OT_Overthrow_Main
 	{
 		author="ARMAzac";
-		name="Overthrow";
+		name=COMPONENT_NAME;
 		url="https://github.com/jabberzac/overthrow";
 		requiredAddons[]=
 		{
@@ -22,7 +24,8 @@ class CfgPatches
             "cba_xeh",
             "cba_jr"
 		};
-		requiredVersion=1.69;
+		requiredVersion=REQUIRED_VERSION;
+        VERSION_CONFIG;
 		units[] = {"OT_GanjaItem","OT_BlowItem"};
 		weapons[] = {"OT_Ganja","OT_Blow"};
 	};
@@ -181,7 +184,7 @@ class CfgWorlds
 	};
 };
 
-#include "macros.hpp"
+#include "CfgSettings.hpp"
 #include "CfgVehicles.hpp"
 #include "CfgWeapons.hpp"
 #include "CfgFunctions.hpp"

--- a/addons/overthrow_main/exception_macros.hpp
+++ b/addons/overthrow_main/exception_macros.hpp
@@ -1,0 +1,45 @@
+/*
+ * Header: exception_macros.hpp
+ *
+ * Description:
+ *     Included as standard header in the main script component header.
+ *
+ * Author:
+ *     Mal
+ *
+ * Arguments:
+ *     n/a
+ *
+ * Returns:
+ *     n/a
+ *
+ * Examples:
+ *     Use as a standard header
+ *     #include "exception_macros.hpp"
+ *
+ * Ref:
+ *     @see https://community.bistudio.com/wiki/PreProcessor_Commands
+ *     @see https://github.com/CBATeam/CBA_A3/wiki/Error-handling
+ */
+
+// @todo requires a more standard framework
+
+#ifndef OT_LOG_VAR
+    #define OT_LOG_VAR(var1) LOG_2(QUOTE(state: var1 [%1]: %2), typeName var1, str var1)
+#endif
+
+#ifndef OT_EX_RPT_TYPE
+    #define OT_EX_RPT_TYPE(var1,var2) ERROR_1(QUOTE(Argument exception - expected var1 but provided %1), typeName var2)
+#endif
+
+#ifndef OT_GUARD_ARRAY
+    #define OT_GUARD_ARRAY(var1,var2) if !(IS_ARRAY(var1)) exitWith { \
+        OT_EX_RPT_TYPE(ARRAY,var1); (var2); \
+    }
+#endif
+
+#ifndef OT_GUARD_OBJECT
+    #define OT_GUARD_OBJECT(var1,var2) if !(IS_OBJECT(var1)) exitWith { \
+        OT_EX_RPT_TYPE(OBJECT,var1); OT_LOG_VAR(var1); { var2 }; \
+    }
+#endif

--- a/addons/overthrow_main/functions/AI/orders/script_component.hpp
+++ b/addons/overthrow_main/functions/AI/orders/script_component.hpp
@@ -1,0 +1,29 @@
+/*
+ * Header: script_component.hpp
+ *
+ * Description:
+ *     Included as standard header in each component and function script.
+ *     Provides useful preprocessor definitions. Note that preprocessor
+ *     commands are case-sensitive. Shamelessly plagiarized from CBA_A3
+ *     as a best practice.
+ *
+ * Author:
+ *     ARMAzac
+ *
+ * Arguments:
+ *     n/a
+ *
+ * Returns:
+ *     n/a
+ *
+ * Examples:
+ *     Use as a standard header
+ *     #include "script_component.hpp"
+ *
+ * Ref:
+ *     @see https://community.bistudio.com/wiki/PreProcessor_Commands
+ *     @see https://github.com/CBATeam/CBA_A3/wiki/Error-handling
+ */
+
+// @todo requires a more standard framework
+#include "\ot\functions\ai\script_component.hpp"

--- a/addons/overthrow_main/functions/AI/script_component.hpp
+++ b/addons/overthrow_main/functions/AI/script_component.hpp
@@ -1,0 +1,29 @@
+/*
+ * Header: script_component.hpp
+ *
+ * Description:
+ *     Included as standard header in each component and function script.
+ *     Provides useful preprocessor definitions. Note that preprocessor
+ *     commands are case-sensitive. Shamelessly plagiarized from CBA_A3
+ *     as a best practice.
+ *
+ * Author:
+ *     ARMAzac
+ *
+ * Arguments:
+ *     n/a
+ *
+ * Returns:
+ *     n/a
+ *
+ * Examples:
+ *     Use as a standard header
+ *     #include "script_component.hpp"
+ *
+ * Ref:
+ *     @see https://community.bistudio.com/wiki/PreProcessor_Commands
+ *     @see https://github.com/CBATeam/CBA_A3/wiki/Error-handling
+ */
+
+// @todo requires a more standard framework
+#include "\ot\functions\script_component.hpp"

--- a/addons/overthrow_main/functions/script_component.hpp
+++ b/addons/overthrow_main/functions/script_component.hpp
@@ -1,0 +1,29 @@
+/*
+ * Header: script_component.hpp
+ *
+ * Description:
+ *     Included as standard header in each component and function script.
+ *     Provides useful preprocessor definitions. Note that preprocessor
+ *     commands are case-sensitive. Shamelessly plagiarized from CBA_A3
+ *     as a best practice.
+ *
+ * Author:
+ *     ARMAzac
+ *
+ * Arguments:
+ *     n/a
+ *
+ * Returns:
+ *     n/a
+ *
+ * Examples:
+ *     Use as a standard header
+ *     #include "script_component.hpp"
+ *
+ * Ref:
+ *     @see https://community.bistudio.com/wiki/PreProcessor_Commands
+ *     @see https://github.com/CBATeam/CBA_A3/wiki/Error-handling
+ */
+
+// @todo requires a more standard framework
+#include "\ot\script_component.hpp"

--- a/addons/overthrow_main/macros.hpp
+++ b/addons/overthrow_main/macros.hpp
@@ -1,3 +1,11 @@
+#include "\x\cba\addons\main\script_macros_common.hpp"
+
+#include "exception_macros.hpp"
+
+#ifndef OT_PFUNC
+    #define OT_PFUNC(var) _##FUNC(var)
+#endif
+
 #define MACRO_ADDITEM(ITEM,COUNT) class _xx_##ITEM { \
     name = #ITEM; \
     count = COUNT; \
@@ -12,3 +20,31 @@
     backpack = #BACKPACK; \
     count = COUNT; \
 }
+
+#ifndef OT_VALID_LOOT_CONTAINERS
+    #define OT_VALID_LOOT_CONTAINERS ["Car","ReammoBox_F","Air","Ship"]
+#endif
+
+#ifndef OT_MAX_WAIT_TIME
+    #define OT_MAX_WAIT_TIME 120
+#endif
+
+#ifndef OT_TARGET_PRECISION_VCLOSE
+    #define OT_TARGET_PRECISION_VCLOSE 10
+#endif
+
+#ifndef OT_TARGET_PRECISION_CLOSE
+    #define OT_TARGET_PRECISION_CLOSE 20
+#endif
+
+#ifndef OT_TARGET_PRECISION_SHORT
+    #define OT_TARGET_PRECISION_SHORT 100
+#endif
+
+#ifndef OT_TARGET_PRECISION_VNEAR
+    #define OT_TARGET_PRECISION_VNEAR 200
+#endif
+
+#ifndef OT_TARGET_PRECISION_NEAR
+    #define OT_TARGET_PRECISION_NEAR 250
+#endif

--- a/addons/overthrow_main/script_component.hpp
+++ b/addons/overthrow_main/script_component.hpp
@@ -1,0 +1,49 @@
+/*
+ * Header: script_component.hpp
+ *
+ * Description:
+ *     Included as standard header in each component and function script.
+ *     Provides useful preprocessor definitions. Note that preprocessor
+ *     commands are case-sensitive. Shamelessly plagiarized from CBA_A3
+ *     as a best practice.
+ *
+ * Author:
+ *     Mal
+ *
+ * Arguments:
+ *     n/a
+ *
+ * Returns:
+ *     n/a
+ *
+ * Examples:
+ *     Use as a standard header
+ *     #include "script_component.hpp"
+ *
+ * Ref:
+ *     @see https://community.bistudio.com/wiki/PreProcessor_Commands
+ *     @see https://github.com/CBATeam/CBA_A3/wiki/Error-handling
+ */
+
+// must define prior to script_mod.hpp
+#define COMPONENT main
+
+#include "\ot\script_mod.hpp"
+
+// Top of \ot\script_component.hpp
+// Ensure that any FULL and NORMAL setting from the individual files are undefined and MINIMAL is set.
+#ifdef DEBUG_MODE_FULL
+    #undef DEBUG_MODE_FULL
+#endif
+
+#ifdef DEBUG_MODE_NORMAL
+    #undef DEBUG_MODE_NORMAL
+#endif
+
+#ifndef DEBUG_MODE_MINIMAL
+    #define DEBUG_MODE_MINIMAL
+#endif
+
+#define DEBUG_SYNCHRONOUS
+
+#include "\ot\macros.hpp"

--- a/addons/overthrow_main/script_mod.hpp
+++ b/addons/overthrow_main/script_mod.hpp
@@ -1,0 +1,52 @@
+/*
+ * Header: script_mod.hpp
+ *
+ * Description:
+ *     Mod's meta header file.
+ *
+ * Author:
+ *     Shamelessly plagiarized from CBA_A3 and ACE3 as a best practice
+ *
+ * Examples:
+ *     in script_component.hpp
+ *     #include "\ot\script_mod.hpp"
+ *
+ * Ref:
+ *     @see https://github.com/CBATeam/CBA_A3/tree/master/addons/main
+ *     @see https://github.com/acemod/ACE3/tree/master/addons/main
+ *
+ * Acknowledgment:
+ *     All applicable licenses and copyrights remain with the original
+ *     author or authors.
+ *     @see https://github.com/CBATeam/CBA_A3/blob/master/LICENSE.md
+ *     @see https://github.com/acemod/ACE3/blob/master/LICENSE
+ */
+
+// these settings work with CBA_A3 common macros
+
+#define MOD_NAME Overthrow
+
+#define PREFIX ot
+
+// version preprocessor definitions before defining strings
+// update the header file before version tagging
+#include "\ot\script_version.hpp"
+
+#define VERSION MAJOR.MINOR.PATCHLVL.BUILD
+
+#define VERSION_AR MAJOR,MINOR,PATCHLVL,BUILD
+
+// MINIMAL required ARMA version for the addon
+#define REQUIRED_VERSION 1.67
+
+// MINIMAL required CBA_A3 version for the addon
+#define REQUIRED_CBA_VERSION {3,3,0}
+
+// MINIMAL required ACE3 version for the addon
+#define REQUIRED_ACE_VERSION {3,9,1}
+
+#ifdef COMPONENT_BEAUTIFIED
+    #define COMPONENT_NAME QUOTE(MOD_NAME - COMPONENT_BEAUTIFIED)
+#else
+    #define COMPONENT_NAME QUOTE(MOD_NAME - COMPONENT)
+#endif

--- a/addons/overthrow_main/script_version.hpp
+++ b/addons/overthrow_main/script_version.hpp
@@ -1,0 +1,22 @@
+/*
+ * Header: script_version.hpp
+ *
+ * Description:
+ *     Preprocessor definitions used to define version. Called
+ *     by script_mod.hpp. Updated prior to a new tag.
+ * 
+ * Author:
+ *     Mal
+ *
+ * Examples:
+ *     in component's script_mod.hpp
+ *     #include "script_version.hpp"
+ *
+ * Ref:
+ *     n/a
+ */
+
+#define MAJOR 0
+#define MINOR 4
+#define PATCHLVL 4
+#define BUILD 0-DEV

--- a/addons/overthrow_main/stringtable.xml
+++ b/addons/overthrow_main/stringtable.xml
@@ -1,0 +1,14 @@
+<!--
+@see https://community.bistudio.com/wiki/localize
+@see https://community.bistudio.com/wiki/Stringtable.xml
+-->
+<?xml version="1.0" encoding="utf-8" ?>
+<Project name="Overthrow">
+    <Package name="Main">
+        <Key ID="STR_Overthrow_Main_Author">
+            <Original>ARMAzac</Original>
+            <English>ARMAzac</English>
+            <French>C'est ARMAzac!</French>
+        </Key>
+    </Package>
+</Project>


### PR DESCRIPTION
Use CBA-style component headers to establish a framework to use pre-processor defs and macros in script files.
